### PR TITLE
DisTauTag updated after input_grid/output_score check 

### DIFF
--- a/Production/plugins/DisTauTag.cc
+++ b/Production/plugins/DisTauTag.cc
@@ -157,7 +157,7 @@ void DisTauTag::saveInputs(const tensorflow::Tensor& tensor, const std::string& 
             (*json_file_) << "[";
             for(int ftr_idx=0; ftr_idx<ftr_n; ftr_idx++)
             {
-                (*json_file_) << tensor.tensor<float, 3>()(tau_idx, pf_idx, ftr_idx);
+                (*json_file_) << std::setprecision(7) << std::fixed << tensor.tensor<float, 3>()(tau_idx, pf_idx, ftr_idx);
                 if(ftr_idx<ftr_n-1) (*json_file_) << ", ";
             }
             (*json_file_) << "]";
@@ -176,8 +176,8 @@ void DisTauTag::produce(edm::Event& event, const edm::EventSetup& setup) {
 
     const size_t jets_size = jets->size();
     
-    std::vector <float> v_score0(jets_size, -9);
-    std::vector <float> v_score1(jets_size, -9);
+    std::vector <Float_t> v_score0(jets_size, -9);
+    std::vector <Float_t> v_score1(jets_size, -9);
 
     // step 1: get jets   
     for(size_t jetIndex = 0; jetIndex < jets_size; ++jetIndex)
@@ -224,46 +224,46 @@ void DisTauTag::produce(edm::Event& event, const edm::EventSetup& setup) {
         {   // General features
             typedef PfCand_Features Br;
             getVecRef(input_1, Br::pfCand_valid                ,1.0);
-            getVecRef(input_1, Br::pfCand_pt                   ,static_cast<float>(daughter->polarP4().pt()));
-            getVecRef(input_1, Br::pfCand_eta                  ,static_cast<float>(daughter->polarP4().eta()));
-            getVecRef(input_1, Br::pfCand_phi                  ,static_cast<float>(daughter->polarP4().phi()));
-            getVecRef(input_1, Br::pfCand_mass                 ,static_cast<float>(daughter->polarP4().mass()));
-            getVecRef(input_1, Br::pfCand_charge               ,static_cast<float>(daughter->charge()));
-            getVecRef(input_1, Br::pfCand_puppiWeight          ,static_cast<float>(daughter->puppiWeight()));
-            getVecRef(input_1, Br::pfCand_puppiWeightNoLep     ,static_cast<float>(daughter->puppiWeightNoLep()));
-            getVecRef(input_1, Br::pfCand_lostInnerHits        ,static_cast<float>(daughter->lostInnerHits()));
-            getVecRef(input_1, Br::pfCand_nPixelHits           ,static_cast<float>(daughter->numberOfPixelHits()));
-            getVecRef(input_1, Br::pfCand_nHits                ,static_cast<float>(daughter->numberOfHits()));
-            getVecRef(input_1, Br::pfCand_caloFraction         ,static_cast<float>(daughter->caloFraction()));
-            getVecRef(input_1, Br::pfCand_hcalFraction         ,static_cast<float>(daughter->hcalFraction()));
-            getVecRef(input_1, Br::pfCand_rawCaloFraction      ,static_cast<float>(daughter->rawCaloFraction()));
-            getVecRef(input_1, Br::pfCand_rawHcalFraction      ,static_cast<float>(daughter->rawHcalFraction()));
+            getVecRef(input_1, Br::pfCand_pt                   ,static_cast<Float_t>(daughter->polarP4().pt()));
+            getVecRef(input_1, Br::pfCand_eta                  ,static_cast<Float_t>(daughter->polarP4().eta()));
+            getVecRef(input_1, Br::pfCand_phi                  ,static_cast<Float_t>(daughter->polarP4().phi()));
+            getVecRef(input_1, Br::pfCand_mass                 ,static_cast<Float_t>(daughter->polarP4().mass()));
+            getVecRef(input_1, Br::pfCand_charge               ,static_cast<Int_t>(daughter->charge()));
+            getVecRef(input_1, Br::pfCand_puppiWeight          ,static_cast<Float_t>(daughter->puppiWeight()));
+            getVecRef(input_1, Br::pfCand_puppiWeightNoLep     ,static_cast<Float_t>(daughter->puppiWeightNoLep()));
+            getVecRef(input_1, Br::pfCand_lostInnerHits        ,static_cast<Int_t>(daughter->lostInnerHits()));
+            getVecRef(input_1, Br::pfCand_nPixelHits           ,static_cast<Int_t>(daughter->numberOfPixelHits()));
+            getVecRef(input_1, Br::pfCand_nHits                ,static_cast<Int_t>(daughter->numberOfHits()));
+            getVecRef(input_1, Br::pfCand_caloFraction         ,static_cast<Float_t>(daughter->caloFraction()));
+            getVecRef(input_1, Br::pfCand_hcalFraction         ,static_cast<Float_t>(daughter->hcalFraction()));
+            getVecRef(input_1, Br::pfCand_rawCaloFraction      ,static_cast<Float_t>(daughter->rawCaloFraction()));
+            getVecRef(input_1, Br::pfCand_rawHcalFraction      ,static_cast<Float_t>(daughter->rawHcalFraction()));
             
-            getVecRef(input_1, Br::pfCand_hasTrackDetails      ,static_cast<float>(daughter->hasTrackDetails()));
+            getVecRef(input_1, Br::pfCand_hasTrackDetails      ,static_cast<Int_t>(daughter->hasTrackDetails()));
 
             if( daughter->hasTrackDetails() )
             {   
-                if(std::isfinite(daughter->dz()))        getVecRef(input_1, Br::pfCand_dz,       static_cast<float>(daughter->dz()));
-                if(std::isfinite(daughter->dzError()))   getVecRef(input_1, Br::pfCand_dz_error, static_cast<float>(daughter->dzError()));
-                if(std::isfinite(daughter->dxyError()))  getVecRef(input_1, Br::pfCand_dxy_error,static_cast<float>(daughter->dxyError()));
+                if(std::isfinite(daughter->dz()))        getVecRef(input_1, Br::pfCand_dz,       static_cast<Float_t>(daughter->dz()));
+                if(std::isfinite(daughter->dzError()))   getVecRef(input_1, Br::pfCand_dz_error, static_cast<Float_t>(daughter->dzError()));
+                if(std::isfinite(daughter->dxyError()))  getVecRef(input_1, Br::pfCand_dxy_error,static_cast<Float_t>(daughter->dxyError()));
 
-                getVecRef(input_1, Br::pfCand_dxy,        static_cast<float>(daughter->dxy()));
-                getVecRef(input_1, Br::pfCand_track_chi2, static_cast<float>(daughter->bestTrack()->chi2()));
-                getVecRef(input_1, Br::pfCand_track_ndof, static_cast<float>(daughter->bestTrack()->ndof()));
+                getVecRef(input_1, Br::pfCand_dxy,        static_cast<Float_t>(daughter->dxy()));
+                getVecRef(input_1, Br::pfCand_track_chi2, static_cast<Float_t>(daughter->bestTrack()->chi2()));
+                getVecRef(input_1, Br::pfCand_track_ndof, static_cast<Float_t>(daughter->bestTrack()->ndof()));
             }
             
-            float jet_eta = jet_p4.eta();
-            float jet_phi = jet_p4.phi();
-            getVecRef(input_1, PfCand_Features::pfCand_deta, static_cast<float>(daughter->polarP4().eta()) - jet_eta);
-            getVecRef(input_1, PfCand_Features::pfCand_dphi, getDeltaPhi<float>(static_cast<float>(daughter->polarP4().eta()), jet_phi));
+            Float_t jet_eta = jet_p4.eta();
+            Float_t jet_phi = jet_p4.phi();
+            getVecRef(input_1, PfCand_Features::pfCand_deta, static_cast<Float_t>(daughter->polarP4().eta()) - jet_eta);
+            getVecRef(input_1, PfCand_Features::pfCand_dphi, getDeltaPhi<Float_t>(static_cast<Float_t>(daughter->polarP4().phi()), jet_phi));
     
         }
 
         {   // Categorical features
             typedef PfCandCategorical_Features Br;
-            getVecRef(input_2, Br::pfCand_particleType         ,static_cast<float>(TranslatePdgIdToPFParticleType(daughter->pdgId())));
-            getVecRef(input_2, Br::pfCand_pvAssociationQuality ,static_cast<float>(daughter->pvAssociationQuality()));
-            getVecRef(input_2, Br::pfCand_fromPV               ,static_cast<float>(daughter->fromPV()));
+            getVecRef(input_2, Br::pfCand_particleType         ,static_cast<Int_t>(TranslatePdgIdToPFParticleType(daughter->pdgId())));
+            getVecRef(input_2, Br::pfCand_pvAssociationQuality ,static_cast<Int_t>(daughter->pvAssociationQuality()));
+            getVecRef(input_2, Br::pfCand_fromPV               ,static_cast<Int_t>(daughter->fromPV()));
         }
 
         ++tensor_idx; 
@@ -277,10 +277,10 @@ void DisTauTag::produce(edm::Event& event, const edm::EventSetup& setup) {
                     {"final_out"}, &outputs);
 
       // print the output
-      std::cout << " jet -> " << jetIndex
-                << " n_pfCand ->" << nDaughters
-                << " score -> " << outputs[0].flat<float>()(0)
-                << " " << outputs[0].flat<float>()(1) << std::endl;
+    //   std::cout << " jet -> " << jetIndex
+    //             << " n_pfCand ->" << nDaughters
+    //             << " score -> " << outputs[0].flat<float>()(0)
+    //             << " " << outputs[0].flat<float>()(1) << std::endl;
     
       v_score0.at(jetIndex) = outputs[0].flat<float>()(0);
       v_score1.at(jetIndex) = outputs[0].flat<float>()(1);

--- a/Production/test/DisTauTag_cfg.py
+++ b/Production/test/DisTauTag_cfg.py
@@ -15,7 +15,7 @@ if not os.path.exists(graph_file_abs):
 
 # setup minimal options
 options = VarParsing("python")
-options.setDefault("inputFiles", "root://xrootd-cms.infn.it//store/mc/RunIIAutumn18MiniAOD/QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15_ext1-v2/270000/01825D94-A8FA-CB45-8048-7F6B6503DB45.root")  # noqa
+options.setDefault("inputFiles", "root://xrootd-cms.infn.it//store/user/myshched/mc/UL2018-pythia-v5-100cm/SUS-RunIISummer20UL18GEN-stau100_lsp1_ctau100mm_v5/MiniAOD/220525_205521/0000/SUS-RunIISummer20UL18MiniAODv2-LLStau_401.root")  # noqa
 options.parseArguments()
 
 # define the process to run
@@ -24,7 +24,7 @@ process = cms.Process("TEST")
 # minimal configuration
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
-process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(1))
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(1000))
 process.source = cms.Source("PoolSource",
     fileNames=cms.untracked.vstring(options.inputFiles))
 

--- a/Production/test/DisTauTag_cfg.py
+++ b/Production/test/DisTauTag_cfg.py
@@ -7,10 +7,9 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 
 
 # get the data/ directory
-# graph_file = 'LLStaus_Run2/Production/data/models/particlenet_v1_a27159734e304ea4b7f9e0042baa9e22.pb'
-# graph_file_abs = os.path.abspath(graph_file)
-# graph_file_abs = "/afs/desy.de/user/m/mykytaua/nfscms/softDeepTau/RecoML/DisTauTag/TauMLTools/Training/python/DisTauTag/mlruns/3/a27159734e304ea4b7f9e0042baa9e22/artifacts/model_graph/graph.pb"
-graph_file_abs = "/nfs/dust/cms/user/mykytaua/softDeepTau/RecoML/DisTauTag/TauMLTools/Training/python/DisTauTag/mlruns/3/9bea2e5d286b46bf86ac51285842be42/artifacts/model_graph/graph.pb"
+graph_file = 'LLStaus_Run2/Production/data/models/particlenet_v1_a27159734e304ea4b7f9e0042baa9e22.pb'
+graph_file_abs = os.path.abspath(graph_file)
+
 if not os.path.exists(graph_file_abs):
     raise Exception("Error: graph_file is not found")
 
@@ -25,7 +24,7 @@ process = cms.Process("TEST")
 # minimal configuration
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
-process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(100))
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(1))
 process.source = cms.Source("PoolSource",
     fileNames=cms.untracked.vstring(options.inputFiles))
 
@@ -36,10 +35,17 @@ process.options = cms.untracked.PSet(
 )
 
 # setup DisTauTag by loading the auto-generated cfi (see DisTauTag.fillDescriptions)
-process.load("LLStaus_Run2.Production.disTauTag_cfi")
-process.disTauTag.graphPath    = cms.string(graph_file_abs)
-process.disTauTag.jets         = cms.InputTag('slimmedJets')
-process.disTauTag.pfCandidates = cms.InputTag('packedPFCandidates')
+# process.load("LLStaus_Run2.Production.disTauTag_cfi")
+# process.disTauTag.graphPath    = cms.string(graph_file_abs)
+# process.disTauTag.jets         = cms.InputTag('slimmedJets')
+# process.disTauTag.pfCandidates = cms.InputTag('packedPFCandidates')
+
+process.disTauTag = cms.EDProducer("DisTauTag",
+    graphPath = cms.string(graph_file_abs),
+    jets         = cms.InputTag('slimmedJets'),
+    pfCandidates = cms.InputTag('packedPFCandidates'),
+    save_inputs  = cms.bool(True)
+)
 
 # define what to run in the path
 process.p = cms.Path(process.disTauTag)


### PR DESCRIPTION
**The input grid:**

The input grid is consistent within the |x_i_python - x_i_cmssw| < 0.0000001

**The input score:**

The consistency is checked within type=float32. In general, results are consistent with the delta that was observed for DeepTau v2p5 implementation. STD within ~ 1.0E-07:
![image](https://user-images.githubusercontent.com/31743376/182126832-1d585045-c5ff-480f-a0ed-9d610208fa1f.png)

however, per 1k studied events (10k jets) 2 junks are observed with deltas 0.005 and 0.0001 on the score value (the input grid for them are still consistent within epsilon 0.0000001
![image](https://user-images.githubusercontent.com/31743376/182127220-5ecacf02-bc71-4311-a1c1-4dac215f01ce.png)

**P.S:**
It was observed that actually the implementation gives quite slow evaluation time (maybe the execution by n-jets together is needed)
